### PR TITLE
This PR adds a MissingDpendencyException to Picotainer. This exception is fired when the entry is found, but the factory method of the entry triggers a NotFoundException (because of a missing dependency fetched from the container).

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Picotainer
 [![Build Status](https://travis-ci.org/thecodingmachine/picotainer.svg?branch=1.0)](https://travis-ci.org/thecodingmachine/picotainer)
 [![Coverage Status](https://coveralls.io/repos/thecodingmachine/picotainer/badge.svg?branch=1.0)](https://coveralls.io/r/thecodingmachine/picotainer?branch=1.0)
 
-This package contains a really minimalist dependency injection container (24 lines of code!) compatible with
+This package contains a really minimalist dependency injection container (26 lines of code!) compatible with
 [container-interop](https://github.com/container-interop/container-interop) (supports ContainerInterface and
 delegate lookup feature).
 

--- a/src/MissingDependencyException.php
+++ b/src/MissingDependencyException.php
@@ -1,0 +1,13 @@
+<?php
+namespace Mouf\Picotainer;
+
+use Interop\Container\Exception\ContainerException;
+
+/**
+ * This exception is thrown when a dependency is not found.
+ *
+ * @author David Négrier <david@mouf-php.com>
+ */
+class MissingDependencyException extends \RuntimeException implements ContainerException
+{
+}

--- a/src/Picotainer.php
+++ b/src/Picotainer.php
@@ -56,8 +56,11 @@ class Picotainer implements ContainerInterface
         if (!isset($this->callbacks[$identifier])) {
             throw new PicotainerNotFoundException(sprintf('Identifier "%s" is not defined.', $identifier));
         }
-
-        return $this->objects[$identifier] = $this->callbacks[$identifier]($this->delegateLookupContainer);
+        try {
+            return $this->objects[$identifier] = $this->callbacks[$identifier]($this->delegateLookupContainer);
+        } catch (PicotainerNotFoundException $e) {
+            throw new MissingDependencyException(sprintf('Entry "%s" cannot be constructed because a dependency is missing.', $identifier, $e));
+        }
     }
 
     /* (non-PHPdoc)

--- a/tests/PicotainerTest.php
+++ b/tests/PicotainerTest.php
@@ -22,13 +22,25 @@ class PicotainerTest extends \PHPUnit_Framework_TestCase
      *
      * @expectedException Mouf\Picotainer\PicotainerNotFoundException
      */
-    public function testGetException()
+    public function testGetNotFoundException()
     {
         $container = new Picotainer([]);
 
         $container->get('nonexistant');
     }
 
+    /**
+     *
+     * @expectedException Mouf\Picotainer\MissingDependencyException
+     */
+    public function testGetMissingDependencyException()
+    {
+        $container = new Picotainer([
+            "instance" => function ($container) { return $container->get('nonfound'); },
+        ]);
+
+        $container->get('instance');
+    }
     public function testDelegateContainer()
     {
         $container = new Picotainer([


### PR DESCRIPTION
The rationale is to make a difference between a `get` method that was passed a wrong ID and a messed up factory. The MissingDependencyException should not be catched while the NotFoundException is meant to be catched.
